### PR TITLE
feat: implement recursive comment tree

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,3 +30,14 @@ export type FullPost = {
   commentsCount: number;
   createdAt: string;
 };
+
+export type CommentNode = {
+  id: number;
+  content: string;
+  postId: number;
+  parentId: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  author: { username: string };
+  replies: CommentNode[];
+};


### PR DESCRIPTION
### What this PR does

- Replaces the existing shallow comment fetch logic with a fully recursive tree structure.
- Uses a single `findMany` query to fetch all comments for a post and reconstructs nested replies in-memory.
- Ensures support for infinite comment depth instead of being limited to just top-level + one reply level.
- Introduces a new `CommentNode` type to represent the recursive comment structure.

### Why this is needed

Previously, the API only returned top-level comments and their direct replies, making deeper threaded conversations impossible. This PR fixes that limitation by enabling full recursion.

### Changes Summary

- Added `buildCommentTree` utility function in `route.ts`
- Modified `GET /api/posts/[id]` to fetch and return a complete comment tree
- Defined `CommentNode` type in `src/types/index.ts` to support recursive typing